### PR TITLE
implement lockdown mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ production tool just yet (**anyone** can add/edit/delete sites!).
 
 - [Setup](#setup)
   - [Configuration](#configuration)
+    - [Lockdown Mode](#lockdown-mode)
   - [Set up a Virtual Environment](#set-up-a-virtual-environment)
   - [Install required Dependencies](#install-required-dependencies)
   - [Migrate the Database](#migrate-the-database)
@@ -61,6 +62,27 @@ MAIL_FROM_NAME="Form Catcher by Seapagan"
 # accidental changes to the API. Defaults to False
 LOCKDOWN=False
 ```
+
+#### Lockdown Mode
+
+Once you have set up your site(s) it can be advantageous to block anyone else
+from creating or editing (or more importantly) deleting the site(s).
+
+For this there is the `LOCKDOWN` environment variable. Set this in the  `.env`
+file as above.
+
+```ini
+LOCKDOWN=False # default, API is open
+```
+
+or
+
+```ini
+LOCKDOWN=True # all routes under '/site' are removed and blocked.
+```
+
+Unless you are operating a public service where people can add their own sites,
+it is recommended to set `LOCKDOWN=True` for any public-facing catcher.
 
 ### Set up a Virtual Environment
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ MAIL_FROM=myemail@gmail.com
 MAIL_PORT=587
 MAIL_SERVER=smtp.mailserver.com
 MAIL_FROM_NAME="Form Catcher by Seapagan"
+
+# Lockdown the API - This will prevent any new sites from being created, or
+# existing sites edited/deleted. This is useful if you want to prevent
+# accidental changes to the API. Defaults to False
+LOCKDOWN=False
 ```
 
 ### Set up a Virtual Environment

--- a/form_catch/config/settings.py
+++ b/form_catch/config/settings.py
@@ -35,6 +35,9 @@ class Settings(BaseSettings):
     mail_use_credentials = True
     mail_validate_certs = True
 
+    # lockdown mode
+    lockdown = False
+
     class Config:
         """Override the default variables from an .env file, if it exsits."""
 

--- a/form_catch/resources/routes.py
+++ b/form_catch/resources/routes.py
@@ -5,10 +5,16 @@ imported by main.
 """
 from fastapi import APIRouter
 
+from form_catch.config.settings import get_settings
 from form_catch.resources import form, home, site
 
 router = APIRouter()
 
+
 router.include_router(home.router)
 router.include_router(form.router)
-router.include_router(site.router)
+
+# Only include the site router if we are not in lockdown mode.
+# we can also remove routes from the other routers if we want to.
+if not get_settings().lockdown:
+    router.include_router(site.router)


### PR DESCRIPTION
Lockout (disable and hide) the `/sites` routes if a specific flag is set in the `.env` file.

This allows a site (or several) to be set up, and then setting this flag will disable any more being created or existing ones modified. Useful for running a personal public service.