### PR TITLE
reject empty form data

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
   allow to catch data for existing sites. This would be helpful to lockdown a
   single-site service after setting up your site. [`Implemented as
   'lockdown'`]
-- [ ] add test for empty form data, don't send email if so.
+- [x] add test for empty form data, don't send email if so.
 - [ ] version the API endpoints for future-proofing.
 - [x] add an 'echo' form_id that will simply echo the results back to you (for
   testing)

--- a/form_catch/resources/form.py
+++ b/form_catch/resources/form.py
@@ -74,6 +74,13 @@ async def respond_to_form(
     # Get the form data depending on the request method
     form_data = await get_form_data(request)
 
+    # Check that the form data is not empty
+    if len([x for x in form_data.values() if x]) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No form data was supplied.",
+        )
+
     # Send the email
     message = MessageSchema(
         subject=f"Form submission for site '{site.name}'",


### PR DESCRIPTION
It will also reject if keys exist but no values.
As long as one key has a value, even if the rest are blank, it will accept data. It is up to the calling app to ensure stuff exists before submitting, this is just to save us bandwidth if they do not.